### PR TITLE
Fixed small typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ using jCenter()
 
 Implement ILightChangeDispatcher to track lights being detected and properties of the lights changing
 ```kotlin
-val changeListener = object : ILightChangeDispatcher {
+val changeListener = object : ILightsChangeDispatcher {
         override fun onLightAdded(light: Light) {
             println("light added : ${light.id}")
         }


### PR DESCRIPTION
Fixed small typo in Readme; it says `ILightChangeDispatcher` when it should be `ILightsChangeDispatcher` (else Android Studio complains about the first override having nothing to override).